### PR TITLE
Update binder link in covid-vax story readme

### DIFF
--- a/stories/covid-vax/README.md
+++ b/stories/covid-vax/README.md
@@ -1,6 +1,6 @@
 # covid-vax
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/alan-turing-institute/TuringDataStories/covid-vax-forecast?filepath=stories%2Fcovid-vax%2Fcovid_vax.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/alan-turing-institute/TuringDataStories/HEAD?filepath=stories%2Fcovid-vax%2Fcovid_vax.ipynb)
 
 Estimating when the UK will finish vaccinating the population. Use the link above
 to run the notebook in Binder, or to run it locally:


### PR DESCRIPTION

### Summary

Updates the URL for the binder button to use master rather than the branch from the pull request.

### List of changes proposed in this PR (pull-request)

- [stories/covid-vax/README.md](https://github.com/alan-turing-institute/TuringDataStories/blob/master/stories/covid-vax/README.md) Binder link
