### PR TITLE
Fix missing brackets in .all-contributorssrc

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -179,6 +179,9 @@
       "contributions": [
         "review",
         "code"
+      ]
+    },
+    {
       "login": "edwardchalstrey1",
       "name": "Ed Chalstrey",
       "avatar_url": "https://avatars.githubusercontent.com/u/5486164?v=4",


### PR DESCRIPTION
Fix all-contributors bot malformed json error caused by missing brackets in .all-contributorssrc