### PR TITLE
Show 2023 results in modelling section

### DIFF
--- a/stories/2024-01-01-Eurovision/story.ipynb
+++ b/stories/2024-01-01-Eurovision/story.ipynb
@@ -2399,10 +2399,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Our baseline model thus predicts Italy to come first, Sweden second, and Ukraine third, simply on the basis of them performing historically well at Eurovision.\n",
+    "Our baseline model thus predicted Italy to come first, Sweden second, and Ukraine third, simply on the basis of them performing historically well at Eurovision.\n",
     "\n",
-    "With the benefit of hindsight, we can calculate the Spearman correlation coefficient for 2023.\n",
-    "Since we cannot really assign a 'rank' to contestants that were eliminated in the semi-finals, this coefficient is calculated only for those countries which made the finals."
+    "In 2023, the top three countries were Sweden (with [Loreen's *Tattoo*](https://www.youtube.com/watch?v=b3vJfR81xO0)), Finland (with [Käärijä's *Cha Cha Cha*](https://www.youtube.com/watch?v=znWi3zN8Ucg)), and Israel (with [Noa Kirel's *Unicorn*](https://www.youtube.com/watch?v=r4wbdKmM3bQ)).\n",
+    "The full results of the final were as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "actual_ranks_2023 = (future.loc[~np.isnan(future['rank'])]\n",
+    "                     .drop_duplicates(subset=['to_country'])\n",
+    "                     .loc[:, ['to_country', 'rank']]\n",
+    "                     .set_index('to_country'))\n",
+    "\n",
+    "actual_ranks_2023.sort_values(by='rank').T"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With the benefit of this hindsight, we can therefore calculate the Spearman correlation coefficient for 2023.\n",
+    "The Spearman coefficient is calculated only for countries which made the finals, since contestants eliminated in the semi-finals cannot really be assigned a 'rank'."
    ]
   },
   {
@@ -2412,11 +2434,6 @@
    "outputs": [],
    "source": [
     "from adjustText import adjust_text\n",
-    "\n",
-    "actual_ranks_2023 = (future.loc[~np.isnan(future['rank'])]\n",
-    "                     .drop_duplicates(subset=['to_country'])\n",
-    "                     .loc[:, ['to_country', 'rank']]\n",
-    "                     .set_index('to_country'))\n",
     "\n",
     "finalists_2023 = actual_ranks_2023.index.unique()\n",
     "predictions_2023_finals = predictions_2023.query('to_country in @finalists_2023')\n",


### PR DESCRIPTION
As discussed earlier

Screenshot of notebook:

<img width="1231" alt="Screenshot 2024-03-22 at 15 29 31" src="https://github.com/alan-turing-institute/TuringDataStories/assets/22414895/47d6d8df-554e-4919-a951-62de45539c44">